### PR TITLE
Update plugin to the new api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-# 2.0.4
+## 3.0.0
+  - Breaking: Updated plugin to use new Java Event APIs
+  - relax logstash-core-plugin-api constrains
+  - update .travis.yml
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/outputs/rackspace.rb
+++ b/lib/logstash/outputs/rackspace.rb
@@ -54,15 +54,11 @@ class LogStash::Outputs::Rackspace < LogStash::Outputs::Base
 
   public
   def receive(event)
-    
-
     begin
-      @rackspace_queue.messages.create :body => event, :ttl => @ttl
-      #@rackspace_queue.messages.create :body => "some data here", :ttl => @ttl
+      @rackspace_queue.messages.create :body => event.to_hash, :ttl => @ttl
     rescue => e
       @logger.warn("Failed to send event to rackspace cloud queues", :event => event, :exception => e,
                    :backtrace => e.backtrace)
     end
-
   end # def receive
 end # class LogStash::Outputs::Rackspace

--- a/logstash-output-rackspace.gemspec
+++ b/logstash-output-rackspace.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-rackspace'
-  s.version         = '2.0.4'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events to Rackspace's Cloud Queue service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,6 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'fog', ['1.20.0']


### PR DESCRIPTION
- Breaking: Updated plugin to use new Java Event APIs
- relax logstash-core-plugin-api constrains
- update .travis.yml
